### PR TITLE
Getting 'cipher not supported' errors with RHEL8/Java 11/Confluent Enterprise 6.2.1

### DIFF
--- a/certificates/create-ca.sh
+++ b/certificates/create-ca.sh
@@ -24,7 +24,7 @@ echo "======================="
 echo ""
 
 printf "\n\ncreated CA key and CA csr\n=========================\n\n"
-openssl req -newkey rsa:1024 -sha1 -passout pass:${ca_password} -keyout ${CERTS}/${key} -out ${CERTS}/${req} -subj ${subject} \
+openssl req -newkey rsa:4096 -sha256 -passout pass:${ca_password} -keyout ${CERTS}/${key} -out ${CERTS}/${req} -subj ${subject} \
 	-reqexts ext \
 	-config <(cat ./openssl.cnf <(printf "\n[ext]\nbasicConstraints=CA:TRUE,pathlen:0"))
 [ $? -eq 1 ] && echo "unable to create CA key and csr" && exit
@@ -38,7 +38,7 @@ openssl req -text -noout -verify -in ${CERTS}/${req}
 [ $? -eq 1 ] && echo "unable to verify CA csr" && exit
 
 printf "\n\nself-sign CA csr\n================\n\n"
-openssl x509 -req -in ${CERTS}/${req} -sha1 -days 365 -passin pass:${ca_password} -signkey ${CERTS}/${key} -out ${CERTS}/${crt} \
+openssl x509 -req -in ${CERTS}/${req} -sha256 -days 365 -passin pass:${ca_password} -signkey ${CERTS}/${key} -out ${CERTS}/${crt} \
 	-extensions ext \
 	-extfile <(cat ./openssl.cnf <(printf "\n[ext]\nbasicConstraints=CA:TRUE,pathlen:0"))
 [ $? -eq 1 ] && echo "unable to self-sign CA csr" && exit

--- a/certificates/create-cert.sh
+++ b/certificates/create-cert.sh
@@ -44,7 +44,7 @@ keystore=${i}.keystore.jks
 printf "\ngenerating key, csr, crt, and p12 file for $i\n\n"
 
 printf "generate key\n============\n\n"
-openssl genrsa -aes128 -passout pass:${B_PW} -out ${CERTS}/${key} 3072
+openssl genrsa -aes256 -passout pass:${B_PW} -out ${CERTS}/${key} 4096
 [ $? -eq 1 ] && echo "unable to generate key for ${i}." && exit
 
 printf "\n\nverify key\n==========\n\n"

--- a/certificates/create-intermediate.sh
+++ b/certificates/create-intermediate.sh
@@ -28,7 +28,7 @@ echo "==============================="
 echo ""
 
 printf "\n\ncreated IN key and IN csr\n=========================\n\n"
-openssl req -newkey rsa:1024 -sha1 -passout pass:${IN_PW} -keyout ${CERTS}/${key} -out ${CERTS}/${req} -subj ${subject}
+openssl req -newkey rsa:4096 -sha256 -passout pass:${IN_PW} -keyout ${CERTS}/${key} -out ${CERTS}/${req} -subj ${subject}
 	-extensions ca \
 	-config <(cat ./openssl.cnf <(printf "\n[ext]\nbasicConstraints=CA:TRUE,pathlen:0"))
 [ $? -eq 1 ] && echo "unable to create IN key and csr" && exit
@@ -42,7 +42,7 @@ openssl req -text -noout -verify -in ${CERTS}/${req}
 [ $? -eq 1 ] && echo "unable to verify IN csr" && exit
 
 printf "\n\nsign IN csr\n===========\n\n"
-openssl x509 -req -CA ${CERTS}/ca.crt -CAkey ${CERTS}/ca.key -passin pass:${CA_PW} -in ${CERTS}/${req} -sha1 -days 365 -out ${CERTS}/${crt} -CAcreateserial \
+openssl x509 -req -CA ${CERTS}/ca.crt -CAkey ${CERTS}/ca.key -passin pass:${CA_PW} -in ${CERTS}/${req} -sha256 -days 365 -out ${CERTS}/${crt} -CAcreateserial \
 	-extensions ext \
 	-extfile <(cat ./openssl.cnf <(printf "\n[ext]\nbasicConstraints=CA:TRUE,pathlen:0"))
 [ $? -eq 1 ] && echo "unable to sign IN csr" && exit


### PR DESCRIPTION
Hi Neil. I was generating some certs for a Kafka cluster with RHEL8/Java 11/Confluent Enterprise 6.2.1. When trying to start the zookeeper servers, I was seeing "cipher not supported" in the ZK servers logs as they were trying to communicate with each another. When I looked into the keystores, the main complaints were that "sha1" was removed for security concerns and RSA keys of 1024 were deprecated because of security concerns. So I upped the keys sizes for all the RSA keys to 4096 (which is probably overkill) and changed the CA and intermediate certs to use SHA-256 instead of SHA-1. Also, changed AES-128 to AES-256 (not necessary but why not). All TLS communication is now working in my cluster, so I thought I'd communicate these changes back to you in case you ran into this in the future.